### PR TITLE
Patch qt-base to fix flatpak runtime dir detection

### DIFF
--- a/bypy/pkgs/qt_base.py
+++ b/bypy/pkgs/qt_base.py
@@ -43,6 +43,9 @@ def main(args):
         # https://bugreports.qt.io/browse/QTBUG-41151
         replace_in_file('src/plugins/platforms/xcb/qxcbcursor.cpp',
                         'pointing_hand"', 'hand2"')
+        # Fix for calibre flatpak runtime directory detection
+        # https://github.com/containers/bubblewrap/issues/346
+        apply_patch('patch_qtbase-revert-correct-handling-for-xdg-runtime-dir.patch', level=1)
     if iswindows or islinux:
         # Let Qt setup its paths based on runtime location
         # this is needed because we want Qt to be able to

--- a/patches/patch_qtbase-revert-correct-handling-for-xdg-runtime-dir.patch
+++ b/patches/patch_qtbase-revert-correct-handling-for-xdg-runtime-dir.patch
@@ -1,0 +1,85 @@
+diff --git a/src/corelib/io/qstandardpaths_unix.cpp b/src/corelib/io/qstandardpaths_unix.cpp
+index 5f4955c53f..ba351acf77 100644
+--- a/src/corelib/io/qstandardpaths_unix.cpp
++++ b/src/corelib/io/qstandardpaths_unix.cpp
+@@ -142,58 +142,53 @@ QString QStandardPaths::writableLocation(StandardLocation type)
+     }
+     case RuntimeLocation:
+     {
+-        // http://standards.freedesktop.org/basedir-spec/latest/
+         const uint myUid = uint(geteuid());
+-        // since the current user is the owner, set both xxxUser and xxxOwner
+-        const QFile::Permissions wantedPerms = QFile::ReadUser | QFile::WriteUser | QFile::ExeUser
+-                                               | QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner;
++        // http://standards.freedesktop.org/basedir-spec/latest/
+         QFileInfo fileInfo;
+         QString xdgRuntimeDir = QFile::decodeName(qgetenv("XDG_RUNTIME_DIR"));
+         if (xdgRuntimeDir.isEmpty()) {
+             const QString userName = QFileSystemEngine::resolveUserName(myUid);
+             xdgRuntimeDir = QDir::tempPath() + QLatin1String("/runtime-") + userName;
+             fileInfo.setFile(xdgRuntimeDir);
++            if (!fileInfo.isDir()) {
++                if (!QDir().mkdir(xdgRuntimeDir)) {
++                    qWarning("QStandardPaths: error creating runtime directory %s: %s", qPrintable(xdgRuntimeDir), qPrintable(qt_error_string(errno)));
++                    return QString();
++                }
++            }
+ #ifndef Q_OS_WASM
+             qWarning("QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '%ls'", qUtf16Printable(xdgRuntimeDir));
+ #endif
+         } else {
+             fileInfo.setFile(xdgRuntimeDir);
+-        }
+-        if (fileInfo.exists()) {
++            if (!fileInfo.exists()) {
++                qWarning("QStandardPaths: XDG_RUNTIME_DIR points to non-existing path '%s', "
++                         "please create it with 0700 permissions.", qPrintable(xdgRuntimeDir));
++                return QString();
++            }
+             if (!fileInfo.isDir()) {
+                 qWarning("QStandardPaths: XDG_RUNTIME_DIR points to '%ls' which is not a directory",
+                          qUtf16Printable(xdgRuntimeDir));
+                 return QString();
+             }
+-        } else {
+-            QFileSystemEntry entry(xdgRuntimeDir);
+-            if (!QFileSystemEngine::createDirectory(entry, false)) {
+-                if (errno != EEXIST) {
+-                    qErrnoWarning("QStandardPaths: error creating runtime directory %ls",
+-                                  qUtf16Printable(xdgRuntimeDir));
+-                    return QString();
+-                }
+-            } else {
+-                QSystemError error;
+-                if (!QFileSystemEngine::setPermissions(entry, wantedPerms, error)) {
+-                    qWarning("QStandardPaths: could not set correct permissions on runtime directory %ls: %ls",
+-                             qUtf16Printable(xdgRuntimeDir), qUtf16Printable(error.toString()));
+-                    return QString();
+-                }
+-            }
+         }
+         // "The directory MUST be owned by the user"
+         if (fileInfo.ownerId() != myUid) {
+-            qWarning("QStandardPaths: wrong ownership on runtime directory %ls, %d instead of %d",
+-                     qUtf16Printable(xdgRuntimeDir),
++            qWarning("QStandardPaths: wrong ownership on runtime directory %s, %d instead of %d", qPrintable(xdgRuntimeDir),
+                      fileInfo.ownerId(), myUid);
+             return QString();
+         }
+         // "and he MUST be the only one having read and write access to it. Its Unix access mode MUST be 0700."
++        // since the current user is the owner, set both xxxUser and xxxOwner
++        const QFile::Permissions wantedPerms = QFile::ReadUser | QFile::WriteUser | QFile::ExeUser
++                                               | QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner;
+         if (fileInfo.permissions() != wantedPerms) {
+-            qWarning("QStandardPaths: wrong permissions on runtime directory %ls, %x instead of %x",
+-                     qUtf16Printable(xdgRuntimeDir), uint(fileInfo.permissions()), uint(wantedPerms));
+-            return QString();
++            QFile file(xdgRuntimeDir);
++            if (!file.setPermissions(wantedPerms)) {
++                qWarning("QStandardPaths: could not set correct permissions on runtime directory %s: %s",
++                         qPrintable(xdgRuntimeDir), qPrintable(file.errorString()));
++                return QString();
++            }
+         }
+ 
+         return xdgRuntimeDir;


### PR DESCRIPTION
This is needed to unbreak calibre flatpak for many users:
https://github.com/flathub/com.calibre_ebook.calibre/issues/39
https://github.com/flathub/com.calibre_ebook.calibre/issues/50

This patch is needed until flatpak/qt solution is found.

I left out other patches as they will be available in qt 5.15.2 very soon so it's not worth additional churn if next calibre release will use 5.15.2 anyway.